### PR TITLE
Rename create command to init

### DIFF
--- a/lib/task_cli/commands/init_command.rb
+++ b/lib/task_cli/commands/init_command.rb
@@ -1,8 +1,8 @@
 require_relative '../command'
 
 class TaskCli
-  class CreateCommand < Command
-    name :create
+  class InitCommand < Command
+    name :init
 
     def run
       return missing_name_error unless argument
@@ -13,7 +13,7 @@ class TaskCli
     private
 
     def missing_name_error
-      'Missing argument <name> in "task_cli create <name>"'
+      'Missing argument <name> in "task_cli init <name>"'
     end
   end
 end

--- a/spec/commands/init_command_spec.rb
+++ b/spec/commands/init_command_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-RSpec.describe 'create Command' do
+RSpec.describe 'init Command' do
   before do
     stub_api(:post, '/tasks').and_return(body: Fixtures.task)
   end
 
   context 'when name argument is present' do
-    let!(:output) { task_cli 'create', 'Clean storage' }
+    let!(:output) { task_cli 'init', 'Clean storage' }
 
     it 'sends the correct request' do
       expect(api_request(:post, '/tasks').with(body: { 'name' => 'Clean storage' })).to have_been_made
@@ -18,14 +18,14 @@ RSpec.describe 'create Command' do
   end
 
   context 'when name argument is absent' do
-    let!(:output) { task_cli 'create' }
+    let!(:output) { task_cli 'init' }
 
     it 'sends no requests' do
       expect(api_request(:post, '/tasks')).to_not have_been_made
     end
 
     it 'returns an error' do
-      expect(output).to eq 'Missing argument <name> in "task_cli create <name>"'
+      expect(output).to eq 'Missing argument <name> in "task_cli init <name>"'
     end
   end
 end

--- a/spec/unit/command_spec.rb
+++ b/spec/unit/command_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe TaskCli::Command do
     let(:command) { described_class.matching(args) }
 
     context 'when argument is a command' do
-      let(:args) { ['create', '-n', '"Some name"'] }
+      let(:args) { ['init', '-n', '"Some name"'] }
 
       it 'returns the matching command' do
-        expect(command.name).to eq :create
+        expect(command.name).to eq :init
       end
     end
 


### PR DESCRIPTION
We rename that command to avoid name conflict with the complete command
we plan to implement.